### PR TITLE
feat: agregar entidad Module y endpoints GET básicos

### DIFF
--- a/src/.idea/.gitignore
+++ b/src/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/.gitignore
+++ b/src/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/src/main/java/com/carsil/userapi/config/SecurityConfig.java
+++ b/src/main/java/com/carsil/userapi/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                                 "/api/users",
                                 "/api/users/**",
                                 "/api/auth/login",
+                                "/api/modules/**",
                                 "/h2-console/**",
                                 "/api/products/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/carsil/userapi/controller/ModuleController.java
+++ b/src/main/java/com/carsil/userapi/controller/ModuleController.java
@@ -1,0 +1,36 @@
+package com.carsil.userapi.controller;
+
+import com.carsil.userapi.model.Module;
+import com.carsil.userapi.service.ModuleService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/modules")
+public class ModuleController {
+
+    private final ModuleService moduleService;
+
+    public ModuleController(ModuleService moduleService) {
+        this.moduleService = moduleService;
+    }
+
+    @GetMapping
+    public List<Module> getAll() {
+        return moduleService.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Module> findById(@PathVariable Long id) {
+        return moduleService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/search")
+    public List<Module> findByName(@RequestParam String name) {
+        return moduleService.findByName(name);
+    }
+}

--- a/src/main/java/com/carsil/userapi/model/Module.java
+++ b/src/main/java/com/carsil/userapi/model/Module.java
@@ -1,0 +1,44 @@
+package com.carsil.userapi.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "app_modules")
+public class Module {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String description;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private float remainingTime = 0f;
+
+    public Module() {}
+
+    public Module(String name) {
+        this.name = name;
+    }
+
+    public Module(String description, String name, float remainingTime) {
+        this.description = description;
+        this.name = name;
+        this.remainingTime = remainingTime;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public float getRemainingTime() { return remainingTime; }
+    public void setRemainingTime(float remainingTime) { this.remainingTime = remainingTime; }
+}

--- a/src/main/java/com/carsil/userapi/repository/ModuleRepository.java
+++ b/src/main/java/com/carsil/userapi/repository/ModuleRepository.java
@@ -1,0 +1,12 @@
+package com.carsil.userapi.repository;
+
+import com.carsil.userapi.model.Module;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ModuleRepository extends JpaRepository<Module, Long> {
+    List<Module> findByNameContainingIgnoreCase(String name);
+}

--- a/src/main/java/com/carsil/userapi/service/ModuleService.java
+++ b/src/main/java/com/carsil/userapi/service/ModuleService.java
@@ -1,0 +1,30 @@
+package com.carsil.userapi.service;
+
+import com.carsil.userapi.model.Module;
+import com.carsil.userapi.repository.ModuleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ModuleService {
+
+    private final ModuleRepository moduleRepository;
+
+    public ModuleService(ModuleRepository moduleRepository) {
+        this.moduleRepository = moduleRepository;
+    }
+
+    public List<Module> getAll() {
+        return moduleRepository.findAll();
+    }
+
+    public Optional<Module> findById(Long id) {
+        return moduleRepository.findById(id);
+    }
+
+    public List<Module> findByName(String name) {
+        return moduleRepository.findByNameContainingIgnoreCase(name);
+    }
+}


### PR DESCRIPTION

Se creó la clase Module con los siguientes campos:

id (Long, obligatorio)

name (String, obligatorio)

description (String, opcional)

remainingTime (Float, obligatorio, inicializado en 0)

Se añadieron ModuleRepository, ModuleService y ModuleController.

Se implementaron endpoints básicos GET:

GET /api/modules → Obtener todos los módulos

GET /api/modules/{id} → Buscar módulo por ID

GET /api/modules/search?name=... → Buscar módulos por nombre